### PR TITLE
wav: ctx_save: clear errors before switching OpenAL context.

### DIFF
--- a/src/wav.c
+++ b/src/wav.c
@@ -102,6 +102,8 @@ ctx_save(alc_t *alc, alc_t *sav)
 {
 	ALuint err;
 
+	(void) alGetError(); // cleanup after other OpenAL users
+
 	if (alc != NULL && alc->ctx == NULL)
 		return (B_TRUE);
 


### PR DESCRIPTION
Other OpenAL users may raise errors w/out checking/clearing them.

Should fix BetterPushbackC #169