### PR TITLE
Make sure we are building for x86_64 on arm macOS

### DIFF
--- a/build_dep.common
+++ b/build_dep.common
@@ -51,9 +51,9 @@ function build_dep() {
 		;;
 	Darwin)
 		NCPUS=$(( $(sysctl -n hw.ncpu) + 1 ))
-		CFLAGS_ADDTL="-mmacosx-version-min=10.9"
-		CXXFLAGS_ADDTL="-mmacosx-version-min=10.9"
-		LDFLAGS_ADDTL="-mmacosx-version-min=10.9"
+		CFLAGS_ADDTL="-mmacosx-version-min=10.9\ -arch\ x86_64"
+		CXXFLAGS_ADDTL="-mmacosx-version-min=10.9\ -arch\ x86_64"
+		LDFLAGS_ADDTL="-mmacosx-version-min=10.9\ -arch\ x86_64"
 		;;
 	esac
 	if [ -n "$BUILD_SINGLE_THREADED" ]; then

--- a/glew/build_glew_deps
+++ b/glew/build_glew_deps
@@ -100,8 +100,10 @@ case `uname` in
 		MAKE_FLAGS="GLEW_PREFIX=$(pwd)/$GLEW-mac-64/install \
 		    GLEW_DEST=$(pwd)/$GLEW-mac-64/install \
 		    CFLAGS.CMDLINE=\"-mmacosx-version-min=10.9 \
+            -arch x86_64 \
 		    -fvisibility=hidden\" \
-		    LDFLAGS.CMDLINE=-mmacosx-version-min=10.9 \
+		    LDFLAGS.CMDLINE=\"-mmacosx-version-min=10.9 \
+            -arch x86_64\" \
 		    $MAKE_FLAGS_COMMON"
 		if ! [ -f "$GLEW-mac-64/install/lib/libGLEWmx.a" ]; then
 			rm -rf "$GLEW-mac-64" && tar xJf "$GLEW_ARCHIVE" && \

--- a/libpng/build_libpng_deps
+++ b/libpng/build_libpng_deps
@@ -37,9 +37,14 @@ case `uname` in
 		    "$LIBPNG" "libpng" "lib/libpng16.a"
 		;;
 	Darwin)
+        # This feels stupid, but libpng checks what architecture the *host* platform is running,
+        # not what the target architecture is when deciding which optimisations to pick. And even
+        # if we were building for arm64, the neon code doesn't compile
+        #
+        # --disable-arm-neon
 		CFLAGS="$CFLAGS_COMMON\\ -mmacosx-version-min=10.6" \
 		    LDFLAGS="$LDFLAGS_COMMON\\ -mmacosx-version-min=10.6" \
-		    build_dep "mac-64" "--enable-static --disable-shared" \
+		    ARCH=x86_64 build_dep "mac-64" "--enable-static --disable-shared --disable-hardware-optimizations --disable-arm-neon" \
 		    "$LIBPNG" "libpng" "lib/libpng16.a"
 		;;
 	*)

--- a/lzma/qmake/qmake.pro
+++ b/lzma/qmake/qmake.pro
@@ -21,6 +21,8 @@ CONFIG += staticlib
 CONFIG += warn_on plugin release
 CONFIG -= thread exceptions qt rtti debug
 
+QMAKE_APPLE_DEVICE_ARCHS = x86_64
+
 VERSION = 1.0.0
 
 INCLUDEPATH += ../C

--- a/qmake/qmake.pro
+++ b/qmake/qmake.pro
@@ -18,6 +18,8 @@ TEMPLATE = lib
 QT -= gui core
 CONFIG += staticlib
 
+QMAKE_APPLE_DEVICE_ARCHS = x86_64
+
 CONFIG += warn_on plugin debug
 CONFIG -= thread exceptions qt rtti release
 


### PR DESCRIPTION
- adds `-arch x86_64` where needed
- sets the proper flag in make `.pro` files