### PR TITLE
Make building with Tesseract optional

### DIFF
--- a/build_deps
+++ b/build_deps
@@ -23,11 +23,11 @@
 
 export minimal=0
 
-while getopts "cdm" opt; do
+while getopts "cdmn" opt; do
 	case $opt in
 	c) export do_clean=1 ;;
 	d) export do_dll=1 ;;
-    n) export no_tesseract=1 ;;
+	n) export no_tesseract=1 ;;
 	m)
 		export minimal=1
 		touch .minimal-deps

--- a/build_deps
+++ b/build_deps
@@ -27,6 +27,7 @@ while getopts "cdm" opt; do
 	case $opt in
 	c) export do_clean=1 ;;
 	d) export do_dll=1 ;;
+    n) export no_tesseract=1 ;;
 	m)
 		export minimal=1
 		touch .minimal-deps
@@ -56,7 +57,7 @@ fi
     ( cd ssl && ./build_ssl_deps ) && \
     ( cd curl && ./build_curl_deps ) && \
     ( [ $minimal -eq 1 ] || ( cd shapelib && ./build_shapelib_deps ) ) && \
-    ( [ $minimal -eq 1 ] || ( cd ocr && ./build_ocr_deps ) ) && \
+    ( [ $minimal -eq 1 ] || [ $no_tesseract -eq 1 ] || ( cd ocr && ./build_ocr_deps ) ) && \
     ( cd pcre2 && ./build_pcre2_deps ) && \
     ( [ $minimal -eq 1 ] || ( cd glew && ./build_glew_deps ) ) && \
     ( [ $minimal -eq 1 ] || ( cd openal-soft && ./build_openal ) ) && \

--- a/pkg-config-deps
+++ b/pkg-config-deps
@@ -96,7 +96,7 @@ done
 
 if ! [ -f .minimal-deps ]; then
 	PACKAGES="$PACKAGES geographiclib"
-	if [[ "$TESSERACT" -ne 0 ]]; then
+	if [[ "$TESSERACT" -ne 0 ]] &&  [ -f "cr/tesseract-$ARCH/lib/pkgconfig/tesseract.pc" ]; then
 		PACKAGES="$PACKAGES tesseract lept"
 	fi
 	if [[ "$CAIRO" -ne 0 ]]; then


### PR DESCRIPTION
- adds a `-n` flag to `build_deps` to bypass building leptonica and tesseract
- pkg-config-deps ignores tesseract if it hasn't been built