### PR TITLE
Install correct dependencies for newer Ubuntu versions

### DIFF
--- a/install-ubuntu-packages
+++ b/install-ubuntu-packages
@@ -17,8 +17,10 @@ if [ "$UBUNTU_MAJOR" -lt 14 ]; then
 	exit 1
 elif [ "$UBUNTU_MAJOR" -eq 14 ]; then
 	PACKAGES="$PACKAGES qt4-qmake qt4-dev-tools"
-else
+elif [ "$UBUNTU_MAJOR" -lt 21 ]; then
 	PACKAGES="$PACKAGES qt5-qmake qt5-default"
+else
+	PACKAGES="$PACKAGES qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools"
 fi
 
 MINIMAL=0


### PR DESCRIPTION
Qt5 package names changed in Ubuntu 21 - this PR installs them if running on a newer version of Ubuntu.

List of dependencies taken from https://askubuntu.com/a/1335187