### PR TITLE
Normalize start up location true heading in `apt.dat`

### DIFF
--- a/src/airportdb.c
+++ b/src/airportdb.c
@@ -1363,7 +1363,7 @@ parse_apt_dat_1300_line(airport_t *arpt, const char *line,
 	rs = safe_calloc(1, sizeof (*rs));
 	lacf_strlcpy(rs->name, srch.name, sizeof (rs->name));
 	rs->pos = GEO_POS2(atof(comps[1]), atof(comps[2]));
-	rs->hdgt = atof(comps[3]);
+	rs->hdgt = normalize_hdg(atof(comps[3]));
 	if (!is_valid_lat(rs->pos.lat) || !is_valid_lon(rs->pos.lon) ||
 	    !is_valid_hdg(rs->hdgt)) {
 		free(rs);


### PR DESCRIPTION
Since sometime prior to 12.06 (possible 12.05?) X-Plane's `apt.dat` started shipping with negative true headings for some start up locations (row code 1300). Fixes https://github.com/skiselkov/libacfutils/issues/21