### PR TITLE
Fix incorrect ISO 639-1 code for Chinese

### DIFF
--- a/src/intl.c
+++ b/src/intl.c
@@ -290,7 +290,7 @@ acfutils_xplang2code(int lang)
 	case xplm_Language_Japanese:
 		return ("ja");
 	case xplm_Language_Chinese:
-		return ("ch");
+		return ("zh");
 	default:
 		return ("xx");
 	}


### PR DESCRIPTION
The ISO 639-1 code for Chinese should be `zh` as documented in [loc.gov](https://www.loc.gov/standards/iso639-2/php/English_list.php). And the incorrect code makes i18n a pain.
The problem was istroduced in 746d8a5b0632b2704743ff290660451b53246d64, so reverting it should fix this problem.