### PR TITLE
Fix quoting issue on MacOS

### DIFF
--- a/build_dep.common
+++ b/build_dep.common
@@ -117,11 +117,11 @@ function build_dep() {
 			    ${XCOMPILE_OPTIONS} \
 			    ${CONFOPTS} "../$SRCDIR" || exit 1
 		else
-			eval CFLAGS="-fvisibility=hidden\\ -O2\\ $FPIC\\ ${CFLAGS}\\ \
+			eval CFLAGS="-fvisibility=hidden\\ -O2\\ $FPIC\\ \"${CFLAGS}\"\\ \
 $CFLAGS_ADDTL" \
-			CXXFLAGS="-fvisibility=hidden\\ -O2\\ $FPIC\\ ${CXXFLAGS}\\ \
+			CXXFLAGS="-fvisibility=hidden\\ -O2\\ $FPIC\\ \"${CXXFLAGS}\"\\ \
 $CXXFLAGS_ADDTL" \
-			LDFLAGS="-fvisibility=hidden\\ $FPIC\\ ${LDFLAGS}\\ \
+			LDFLAGS="-fvisibility=hidden\\ $FPIC\\ \"${LDFLAGS}\"\\ \
 $LDFLAGS_ADDTL" \
 			    "../$SRCDIR/configure" --prefix="$(pwd)/$INSTALL_DIR" \
 			    ${CONFOPTS} || exit 1


### PR DESCRIPTION
Build unhappy on my macOS 14.4 / homebrew machine due to a space in `$LDFLAGS`; fix this and potential same issue in `$CFLAGS` and `$CXXFLAGS`.