### PR TITLE
Add free to stop leaking buf in extract_TA_TL_ft

### DIFF
--- a/src/airportdb.c
+++ b/src/airportdb.c
@@ -1440,6 +1440,7 @@ extract_TA_TL_ft(char *const*comps, size_t n_comps)
 		if (metric && MET2FEET(alt) < 60000) {
 			alt = MET2FEET(alt);
 		}
+		free(buf);
 		return (SOME(alt));
 	} else {
 		free(buf);


### PR DESCRIPTION
As I mentioned in #software-dev, Instruments on MacOS was pointing to buf as leaking some memory, I found adding an extra free(buf) before returning the altitude stopped it complaining about it.